### PR TITLE
vhost_user: Add support for VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 epoll = ">=4.0.1"
 libc = ">=0.2.39"
 log = ">=0.4.6"
-vhost_rs = { git = "https://github.com/rust-vmm/vhost", package = "vhost", features = ["vhost-user-slave"] }
+vhost = { git = "https://github.com/rust-vmm/vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = {version = ">=0.2.0", features = ["backend-mmap", "backend-atomic"]}
 vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,11 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::result;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
-use vhost_rs::vhost_user::message::{
+use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
-use vhost_rs::vhost_user::{
+use vhost::vhost_user::{
     Error as VhostUserError, Listener, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
     VhostUserSlaveReqHandler,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,6 +873,10 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
     }
 
     fn set_slave_req_fd(&mut self, vu_req: SlaveFsCacheReq) {
+        if self.acked_protocol_features & VhostUserProtocolFeatures::REPLY_ACK.bits() != 0 {
+            vu_req.set_reply_ack_flag(true);
+        }
+
         self.backend.write().unwrap().set_slave_req_fd(vu_req);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{
     Error as VhostUserError, Listener, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
-    VhostUserSlaveReqHandler,
+    VhostUserSlaveReqHandlerMut,
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::guest_memory::FileOffset;
@@ -553,7 +553,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
     }
 }
 
-impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
+impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
     fn set_owner(&mut self) -> VhostUserResult<()> {
         if self.owned {
             return Err(VhostUserError::InvalidOperation);


### PR DESCRIPTION
This PR introduces the support for recently added message types `VHOST_USER_GET_MAX_MEM_SLOTS`, `VHOST_USER_ADD_MEM_REG` and `VHOST_USER_REM_MEM_REG`, coming from the latest vhost-user specification, and gated by the protocol feature `VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS`.