### PR TITLE
Fixes to enable CI 

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-musl]
+rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc"]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 0,
+  "exclude_path": "",
+  "crate_features": ""
+}


### PR DESCRIPTION
- Added a default `coverage_config_x86_64.json` and `coverage_score` set to 0 
- Added build flags for `aarch64-unknown-linux-musl` - https://github.com/rust-vmm/vm-virtio/commit/9d31dc0b51a4c7098665df57064a31847d9bb1ea

Fixes #7. 