### PR TITLE
Add gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target


### PR DESCRIPTION
When building, cargo generates a `Cargo.lock` file and a `target` directory. We don't want either in source control, so add them both to `.gitignore`.