### PR TITLE
Minimally fix breakage from upstream changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ log = ">=0.4.6"
 vhost = { git = "https://github.com/rust-vmm/vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = {version = ">=0.2.0", features = ["backend-mmap", "backend-atomic"]}
-vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio" }
+virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -769,10 +769,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if let Some(kick) = self.vrings[index as usize].write().unwrap().kick.take() {
-            // Close file descriptor set by previous operations.
-            let _ = unsafe { libc::close(kick.as_raw_fd()) };
-        }
         // SAFETY: EventFd requires that it has sole ownership of its fd. So
         // does File, so this is safe.
         // Ideally, we'd have a generic way to refer to a uniquely-owned fd,
@@ -811,10 +807,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if let Some(call) = self.vrings[index as usize].write().unwrap().call.take() {
-            // Close file descriptor set by previous operations.
-            let _ = unsafe { libc::close(call.as_raw_fd()) };
-        }
         // SAFETY: see comment in set_vring_kick()
         self.vrings[index as usize].write().unwrap().call =
             file.map(|f| unsafe { EventFd::from_raw_fd(f.into_raw_fd()) });
@@ -827,10 +819,6 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
             return Err(VhostUserError::InvalidParam);
         }
 
-        if let Some(err) = self.vrings[index as usize].write().unwrap().err.take() {
-            // Close file descriptor set by previous operations.
-            let _ = unsafe { libc::close(err.as_raw_fd()) };
-        }
         // SAFETY: see comment in set_vring_kick()
         self.vrings[index as usize].write().unwrap().err =
             file.map(|f| unsafe { EventFd::from_raw_fd(f.into_raw_fd()) });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -945,6 +945,20 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
 
         Ok(())
     }
+
+    fn get_inflight_fd(
+        &mut self,
+        _inflight: &vhost::vhost_user::message::VhostUserInflight,
+    ) -> VhostUserResult<(vhost::vhost_user::message::VhostUserInflight, File)> {
+        // Assume the backend hasn't negotiated the inflight feature; it
+        // wouldn't be correct for the backend to do so, as we don't (yet)
+        // provide a way for it to handle such requests.
+        Err(VhostUserError::InvalidOperation)
+    }
+
+    fn set_inflight_fd(&mut self, _inflight: &vhost::vhost_user::message::VhostUserInflight, _file: File) -> VhostUserResult<()> {
+        Err(VhostUserError::InvalidOperation)
+    }
 }
 
 impl<S: VhostUserBackend> Drop for VhostUserHandler<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use vm_memory::{
     GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap, GuestRegionMmap,
     MmapRegion,
 };
-use vm_virtio::Queue;
+use virtio_queue::Queue;
 use vmm_sys_util::eventfd::EventFd;
 
 const MAX_MEM_SLOTS: u64 = 32;


### PR DESCRIPTION
This PR does the minimum necessary to get things building after some breaking changes to the vm-virtio and vhost projects. There may be better ways to respond to some of these changes—I detail these below and in the commit messages—but this PR aims to get things compiling and working again in a simple and bikeshed-free way while we figure out an eventual solution.

In particular, this PR:

- Renames vm-virtio to virtio-queue (the former was split into several crates; everything we use is in virtio-queue).
- Converts our VhostUserSlaveReqHandlerMut to the new signatures, which use File instead of RawFd.

  In most cases, we were converting the RawFd into a File anyway, and  the new code is trivial. In a few cases, though, we actually want an  EventFd, which now requires this nasty construction:

  ```
  unsafe { EventFd::from_raw_fd(file.as_raw_fd())
  ```

  This is safe—EventFd::from_raw_fd is unsafe becuase it expects to  uniquely own its fd, an invariant File also has—but a little   inelegant.

  Ideally, we would either (a) change vmm-sys-util to provide a way to  safely create an EventFd from a File (this would be trivial; EventFd  actually stores its fd as a File internally), (b) pass around a  generic "uniquely owned fd" struct (like that propsed by Rust RFC)  #3128 instead of a File, or (c) change vhost to pass us an EventFd  instead of a File where appropriate (which, in practice, would mean  implementing (a) or (b) in vhost).
- "Implements" {get,set}_inflight_fd.

  This implementation just returns Err(InvalidOperation), which is the  correct response for a backend that hasn't negotiated the inflight  feature. Eventually, it'd be nice if we allowed the backend to  negotiate this feature; harshanavkis@8b44378 and slp@3346318 are two  attempts at this.
