### PR TITLE
epoll: use epoll wrapper from vmm-sys-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-epoll = ">=4.0.1"
 libc = ">=0.2.39"
 log = ">=0.4.6"
 vhost = { version = "0.2", features = ["vhost-user-slave"] }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 78.8,
+  "coverage_score": 78.5,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use vhost::vhost_user::message::VhostUserProtocolFeatures;
 use vhost::vhost_user::SlaveFsCacheReq;
 use vm_memory::bitmap::Bitmap;
+use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::vring::VringT;
@@ -111,7 +112,7 @@ where
     fn handle_event(
         &self,
         device_event: u16,
-        evset: epoll::Events,
+        evset: EventSet,
         vrings: &[V],
         thread_id: usize,
     ) -> result::Result<bool, io::Error>;
@@ -194,7 +195,7 @@ where
     fn handle_event(
         &mut self,
         device_event: u16,
-        evset: epoll::Events,
+        evset: EventSet,
         vrings: &[V],
         thread_id: usize,
     ) -> result::Result<bool, io::Error>;
@@ -256,7 +257,7 @@ where
     fn handle_event(
         &self,
         device_event: u16,
-        evset: epoll::Events,
+        evset: EventSet,
         vrings: &[V],
         thread_id: usize,
     ) -> Result<bool, io::Error> {
@@ -321,7 +322,7 @@ where
     fn handle_event(
         &self,
         device_event: u16,
-        evset: epoll::Events,
+        evset: EventSet,
         vrings: &[V],
         thread_id: usize,
     ) -> Result<bool, io::Error> {
@@ -387,7 +388,7 @@ where
     fn handle_event(
         &self,
         device_event: u16,
-        evset: epoll::Events,
+        evset: EventSet,
         vrings: &[V],
         thread_id: usize,
     ) -> Result<bool, io::Error> {
@@ -401,7 +402,6 @@ where
 pub mod tests {
     use super::*;
     use crate::VringRwLock;
-    use epoll::Events;
     use std::io::Error;
     use std::sync::Mutex;
     use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
@@ -484,7 +484,7 @@ pub mod tests {
         fn handle_event(
             &mut self,
             _device_event: u16,
-            _evset: Events,
+            _evset: EventSet,
             _vrings: &[VringRwLock],
             _thread_id: usize,
         ) -> Result<bool, Error> {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,6 +25,7 @@ use vm_memory::mmap::NewBitmap;
 use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryMmap, GuestRegionMmap, MmapRegion,
 };
+use vmm_sys_util::epoll::EventSet;
 
 use super::backend::VhostUserBackend;
 use super::event_loop::VringEpollHandler;
@@ -196,7 +197,7 @@ where
                 if shifted_queues_mask & 1u64 == 1u64 {
                     let evt_idx = queues_mask.count_ones() - shifted_queues_mask.count_ones();
                     self.handlers[thread_index]
-                        .register_event(fd.as_raw_fd(), epoll::Events::EPOLLIN, u64::from(evt_idx))
+                        .register_event(fd.as_raw_fd(), EventSet::IN, u64::from(evt_idx))
                         .map_err(VhostUserError::ReqHandlerError)?;
                     break;
                 }
@@ -382,11 +383,7 @@ where
                 if shifted_queues_mask & 1u64 == 1u64 {
                     let evt_idx = queues_mask.count_ones() - shifted_queues_mask.count_ones();
                     self.handlers[thread_index]
-                        .unregister_event(
-                            fd.as_raw_fd(),
-                            epoll::Events::EPOLLIN,
-                            u64::from(evt_idx),
-                        )
+                        .unregister_event(fd.as_raw_fd(), EventSet::IN, u64::from(evt_idx))
                         .map_err(VhostUserError::ReqHandlerError)?;
                     break;
                 }


### PR DESCRIPTION
There's a wrapper for epoll from vmm-sys-util, so use the wrapper
instead of the epoll crate directly. It may help to ease dependency
management.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>