### PR TITLE
Refine VringStateGuard/VringStateMutGuard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic"]}
 vmm-sys-util = "0.9"
 
 [dev-dependencies]
+nix = "0.22"
+vhost = { version = "0.3", features = ["vhost-user-master", "vhost-user-slave"] }
 vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic", "backend-bitmap"]}
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0"
 [dependencies]
 libc = ">=0.2.39"
 log = ">=0.4.6"
-vhost = { version = "0.2", features = ["vhost-user-slave"] }
+vhost = { version = "0.3", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1"
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", rev = "cc1fa35" }
+virtio-queue = "0.1"
 vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic"]}
 vmm-sys-util = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ vmm-sys-util = "0.9"
 
 [dev-dependencies]
 vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic", "backend-bitmap"]}
+tempfile = "3.2.0"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 78.5,
+  "coverage_score": 49.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 49.6,
+  "coverage_score": 87.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -33,9 +33,8 @@ use super::GM;
 
 /// Trait with interior mutability for vhost user backend servers to implement concrete services.
 ///
-/// To support multi-threading and asynchronous IO, we enforce `the Send + Sync + 'static`.
-/// So there's no plan for support of "Rc<T>" and "RefCell<T>".
-pub trait VhostUserBackend<V, B = ()>: Send + Sync + 'static
+/// To support multi-threading and asynchronous IO, we enforce `Send + Sync` bound.
+pub trait VhostUserBackend<V, B = ()>: Send + Sync
 where
     V: VringT<GM<B>>,
     B: Bitmap + 'static,
@@ -118,7 +117,7 @@ where
 }
 
 /// Trait without interior mutability for vhost user backend servers to implement concrete services.
-pub trait VhostUserBackendMut<V, B = ()>: Send + Sync + 'static
+pub trait VhostUserBackendMut<V, B = ()>: Send + Sync
 where
     V: VringT<GM<B>>,
     B: Bitmap + 'static,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Formatter};
-use std::io;
+use std::io::{self, Result};
 use std::marker::PhantomData;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::result;
 
 use vm_memory::bitmap::Bitmap;
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
@@ -127,12 +126,7 @@ where
     ///
     /// When this event is later triggered, the backend implementation of `handle_event` will be
     /// called.
-    pub fn register_listener(
-        &self,
-        fd: RawFd,
-        ev_type: EventSet,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub fn register_listener(&self, fd: RawFd, ev_type: EventSet, data: u64) -> Result<()> {
         // `data` range [0...num_queues] is reserved for queues and exit event.
         if data <= self.backend.num_queues() as u64 {
             Err(io::Error::from_raw_os_error(libc::EINVAL))
@@ -145,12 +139,7 @@ where
     ///
     /// If the event is triggered after this function has been called, the event will be silently
     /// dropped.
-    pub fn unregister_listener(
-        &self,
-        fd: RawFd,
-        ev_type: EventSet,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub fn unregister_listener(&self, fd: RawFd, ev_type: EventSet, data: u64) -> Result<()> {
         // `data` range [0...num_queues] is reserved for queues and exit event.
         if data <= self.backend.num_queues() as u64 {
             Err(io::Error::from_raw_os_error(libc::EINVAL))
@@ -159,22 +148,12 @@ where
         }
     }
 
-    pub(crate) fn register_event(
-        &self,
-        fd: RawFd,
-        ev_type: EventSet,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub(crate) fn register_event(&self, fd: RawFd, ev_type: EventSet, data: u64) -> Result<()> {
         self.epoll
             .ctl(ControlOperation::Add, fd, EpollEvent::new(ev_type, data))
     }
 
-    pub(crate) fn unregister_event(
-        &self,
-        fd: RawFd,
-        ev_type: EventSet,
-        data: u64,
-    ) -> result::Result<(), io::Error> {
+    pub(crate) fn unregister_event(&self, fd: RawFd, ev_type: EventSet, data: u64) -> Result<()> {
         self.epoll
             .ctl(ControlOperation::Delete, fd, EpollEvent::new(ev_type, data))
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -262,18 +262,6 @@ where
         Ok(())
     }
 
-    fn get_protocol_features(&mut self) -> VhostUserResult<VhostUserProtocolFeatures> {
-        Ok(self.backend.protocol_features())
-    }
-
-    fn set_protocol_features(&mut self, features: u64) -> VhostUserResult<()> {
-        // Note: slave that reported VHOST_USER_F_PROTOCOL_FEATURES must
-        // support this message even before VHOST_USER_SET_FEATURES was
-        // called.
-        self.acked_protocol_features = features;
-        Ok(())
-    }
-
     fn set_mem_table(
         &mut self,
         ctx: &[VhostUserMemoryRegion],
@@ -313,10 +301,6 @@ where
         self.mappings = mappings;
 
         Ok(())
-    }
-
-    fn get_queue_num(&mut self) -> VhostUserResult<u64> {
-        Ok(self.num_queues as u64)
     }
 
     fn set_vring_num(&mut self, index: u32, num: u32) -> VhostUserResult<()> {
@@ -448,6 +432,22 @@ where
         Ok(())
     }
 
+    fn get_protocol_features(&mut self) -> VhostUserResult<VhostUserProtocolFeatures> {
+        Ok(self.backend.protocol_features())
+    }
+
+    fn set_protocol_features(&mut self, features: u64) -> VhostUserResult<()> {
+        // Note: slave that reported VHOST_USER_F_PROTOCOL_FEATURES must
+        // support this message even before VHOST_USER_SET_FEATURES was
+        // called.
+        self.acked_protocol_features = features;
+        Ok(())
+    }
+
+    fn get_queue_num(&mut self) -> VhostUserResult<u64> {
+        Ok(self.num_queues as u64)
+    }
+
     fn set_vring_enable(&mut self, index: u32, enable: bool) -> VhostUserResult<()> {
         // This request should be handled only when VHOST_USER_F_PROTOCOL_FEATURES
         // has been negotiated.
@@ -492,6 +492,24 @@ where
         }
 
         self.backend.set_slave_req_fd(vu_req);
+    }
+
+    fn get_inflight_fd(
+        &mut self,
+        _inflight: &vhost::vhost_user::message::VhostUserInflight,
+    ) -> VhostUserResult<(vhost::vhost_user::message::VhostUserInflight, File)> {
+        // Assume the backend hasn't negotiated the inflight feature; it
+        // wouldn't be correct for the backend to do so, as we don't (yet)
+        // provide a way for it to handle such requests.
+        Err(VhostUserError::InvalidOperation)
+    }
+
+    fn set_inflight_fd(
+        &mut self,
+        _inflight: &vhost::vhost_user::message::VhostUserInflight,
+        _file: File,
+    ) -> VhostUserResult<()> {
+        Err(VhostUserError::InvalidOperation)
     }
 
     fn get_max_mem_slots(&mut self) -> VhostUserResult<u64> {
@@ -560,24 +578,6 @@ where
             .retain(|mapping| mapping.gpa_base != region.guest_phys_addr);
 
         Ok(())
-    }
-
-    fn get_inflight_fd(
-        &mut self,
-        _inflight: &vhost::vhost_user::message::VhostUserInflight,
-    ) -> VhostUserResult<(vhost::vhost_user::message::VhostUserInflight, File)> {
-        // Assume the backend hasn't negotiated the inflight feature; it
-        // wouldn't be correct for the backend to do so, as we don't (yet)
-        // provide a way for it to handle such requests.
-        Err(VhostUserError::InvalidOperation)
-    }
-
-    fn set_inflight_fd(
-        &mut self,
-        _inflight: &vhost::vhost_user::message::VhostUserInflight,
-        _file: File,
-    ) -> VhostUserResult<()> {
-        Err(VhostUserError::InvalidOperation)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 extern crate log;
 
 use std::fmt::{Display, Formatter};
-use std::io;
-use std::result;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -48,7 +46,7 @@ pub enum Error {
     /// Failed creating vhost-user slave handler.
     CreateSlaveReqHandler(VhostUserError),
     /// Failed starting daemon thread.
-    StartDaemon(io::Error),
+    StartDaemon(std::io::Error),
     /// Failed waiting for daemon thread.
     WaitDaemon(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     /// Failed handling a vhost-user request.
@@ -69,7 +67,7 @@ impl Display for Error {
 }
 
 /// Result of vhost-user daemon operations.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Implement a simple framework to run a vhost-user service daemon.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,12 +73,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// This structure is the public API the backend is allowed to interact with in order to run
 /// a fully functional vhost-user daemon.
-pub struct VhostUserDaemon<S, V, B = ()>
-where
-    S: VhostUserBackend<V, B>,
-    V: VringT<GM<B>> + Clone + Send + Sync + 'static,
-    B: Bitmap + 'static,
-{
+pub struct VhostUserDaemon<S, V, B: Bitmap + 'static = ()> {
     name: String,
     handler: Arc<Mutex<VhostUserHandler<S, V, B>>>,
     main_thread: Option<thread::JoinHandle<Result<()>>>,
@@ -86,7 +81,7 @@ where
 
 impl<S, V, B> VhostUserDaemon<S, V, B>
 where
-    S: VhostUserBackend<V, B> + Clone,
+    S: VhostUserBackend<V, B> + Clone + 'static,
     V: VringT<GM<B>> + Clone + Send + Sync + 'static,
     B: NewBitmap + Clone + Send + Sync,
 {
@@ -167,6 +162,7 @@ where
     /// This is necessary to perform further actions like registering and unregistering some extra
     /// event file descriptors.
     pub fn get_epoll_handlers(&self) -> Vec<Arc<VringEpollHandler<S, V, B>>> {
+        // Do not expect poisoned lock.
         self.handler.lock().unwrap().get_epoll_handlers()
     }
 }

--- a/tests/vhost-user-server.rs
+++ b/tests/vhost-user-server.rs
@@ -1,0 +1,297 @@
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Result;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
+
+use vhost::vhost_user::message::{
+    VhostUserConfigFlags, VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures,
+};
+use vhost::vhost_user::{Listener, Master, SlaveFsCacheReq, VhostUserMaster};
+use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
+use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
+use vm_memory::{
+    FileOffset, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
+};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
+struct MockVhostBackend {
+    events: u64,
+    event_idx: bool,
+    acked_features: u64,
+}
+
+impl MockVhostBackend {
+    fn new() -> Self {
+        MockVhostBackend {
+            events: 0,
+            event_idx: false,
+            acked_features: 0,
+        }
+    }
+}
+
+impl VhostUserBackendMut<VringRwLock, ()> for MockVhostBackend {
+    fn num_queues(&self) -> usize {
+        2
+    }
+
+    fn max_queue_size(&self) -> usize {
+        256
+    }
+
+    fn features(&self) -> u64 {
+        0xffff_ffff_ffff_ffff
+    }
+
+    fn acked_features(&mut self, features: u64) {
+        self.acked_features = features;
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::all()
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.event_idx = enabled;
+    }
+
+    fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
+        assert_eq!(offset, 0x200);
+        assert_eq!(size, 8);
+
+        vec![0xa5u8; 8]
+    }
+
+    fn set_config(&mut self, offset: u32, buf: &[u8]) -> Result<()> {
+        assert_eq!(offset, 0x200);
+        assert_eq!(buf, &[0xa5u8; 8]);
+
+        Ok(())
+    }
+
+    fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
+        let mem = atomic_mem.memory();
+        let region = mem.find_region(GuestAddress(0x100000)).unwrap();
+        assert_eq!(region.size(), 0x100000);
+        Ok(())
+    }
+
+    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
+
+    fn queues_per_thread(&self) -> Vec<u64> {
+        vec![1, 1]
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+        let event_fd = EventFd::new(0).unwrap();
+
+        Some(event_fd)
+    }
+
+    fn handle_event(
+        &mut self,
+        _device_event: u16,
+        _evset: EventSet,
+        _vrings: &[VringRwLock],
+        _thread_id: usize,
+    ) -> Result<bool> {
+        self.events += 1;
+
+        Ok(false)
+    }
+}
+
+fn setup_master(path: &Path, barrier: Arc<Barrier>) -> Master {
+    barrier.wait();
+    let mut master = Master::connect(path, 1).unwrap();
+    master.set_hdr_flags(VhostUserHeaderFlag::NEED_REPLY);
+    // Wait before issue service requests.
+    barrier.wait();
+
+    let features = master.get_features().unwrap();
+    let proto = master.get_protocol_features().unwrap();
+    master.set_features(features).unwrap();
+    master.set_protocol_features(proto).unwrap();
+    assert!(proto.contains(VhostUserProtocolFeatures::REPLY_ACK));
+
+    master
+}
+
+fn vhost_user_client(path: &Path, barrier: Arc<Barrier>) {
+    barrier.wait();
+    let mut master = Master::connect(path, 1).unwrap();
+    master.set_hdr_flags(VhostUserHeaderFlag::NEED_REPLY);
+    // Wait before issue service requests.
+    barrier.wait();
+
+    let features = master.get_features().unwrap();
+    let proto = master.get_protocol_features().unwrap();
+    master.set_features(features).unwrap();
+    master.set_protocol_features(proto).unwrap();
+    assert!(proto.contains(VhostUserProtocolFeatures::REPLY_ACK));
+
+    let queue_num = master.get_queue_num().unwrap();
+    assert_eq!(queue_num, 2);
+
+    master.set_owner().unwrap();
+    //master.set_owner().unwrap_err();
+    master.reset_owner().unwrap();
+    master.reset_owner().unwrap();
+    master.set_owner().unwrap();
+
+    master.set_features(features).unwrap();
+    master.set_protocol_features(proto).unwrap();
+    assert!(proto.contains(VhostUserProtocolFeatures::REPLY_ACK));
+
+    let memfd = nix::sys::memfd::memfd_create(
+        &CString::new("test").unwrap(),
+        nix::sys::memfd::MemFdCreateFlag::empty(),
+    )
+    .unwrap();
+    let file = unsafe { File::from_raw_fd(memfd) };
+    file.set_len(0x100000).unwrap();
+    let file_offset = FileOffset::new(file, 0);
+    let mem = GuestMemoryMmap::<()>::from_ranges_with_files(&[(
+        GuestAddress(0x100000),
+        0x100000,
+        Some(file_offset),
+    )])
+    .unwrap();
+    let addr = mem.get_host_address(GuestAddress(0x100000)).unwrap() as u64;
+    let reg = mem.find_region(GuestAddress(0x100000)).unwrap();
+    let fd = reg.file_offset().unwrap();
+    let regions = [VhostUserMemoryRegionInfo {
+        guest_phys_addr: 0x100000,
+        memory_size: 0x100000,
+        userspace_addr: addr,
+        mmap_offset: 0,
+        mmap_handle: fd.file().as_raw_fd(),
+    }];
+    master.set_mem_table(&regions).unwrap();
+
+    master.set_vring_num(0, 256).unwrap();
+
+    let config = VringConfigData {
+        queue_max_size: 256,
+        queue_size: 256,
+        flags: 0,
+        desc_table_addr: addr,
+        used_ring_addr: addr + 0x10000,
+        avail_ring_addr: addr + 0x20000,
+        log_addr: None,
+    };
+    master.set_vring_addr(0, &config).unwrap();
+
+    let eventfd = EventFd::new(0).unwrap();
+    master.set_vring_kick(0, &eventfd).unwrap();
+    master.set_vring_call(0, &eventfd).unwrap();
+    master.set_vring_err(0, &eventfd).unwrap();
+    master.set_vring_enable(0, true).unwrap();
+
+    let buf = [0u8; 8];
+    let (_cfg, data) = master
+        .get_config(0x200, 8, VhostUserConfigFlags::empty(), &buf)
+        .unwrap();
+    assert_eq!(&data, &[0xa5u8; 8]);
+    master
+        .set_config(0x200, VhostUserConfigFlags::empty(), &data)
+        .unwrap();
+
+    let (tx, _rx) = UnixStream::pair().unwrap();
+    master.set_slave_request_fd(&tx).unwrap();
+
+    let state = master.get_vring_base(0).unwrap();
+    master.set_vring_base(0, state as u16).unwrap();
+
+    assert_eq!(master.get_max_mem_slots().unwrap(), 32);
+    let region = VhostUserMemoryRegionInfo {
+        guest_phys_addr: 0x800000,
+        memory_size: 0x100000,
+        userspace_addr: addr,
+        mmap_offset: 0,
+        mmap_handle: fd.file().as_raw_fd(),
+    };
+    master.add_mem_region(&region).unwrap();
+    master.remove_mem_region(&region).unwrap();
+}
+
+fn vhost_user_server(cb: fn(&Path, Arc<Barrier>)) {
+    let mem = GuestMemoryAtomic::new(GuestMemoryMmap::<()>::new());
+    let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
+    let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
+
+    let barrier = Arc::new(Barrier::new(2));
+    let tmpdir = tempfile::tempdir().unwrap();
+    let mut path = tmpdir.path().to_path_buf();
+    path.push("socket");
+
+    let barrier2 = barrier.clone();
+    let path1 = path.clone();
+    let thread = thread::spawn(move || cb(&path1, barrier2));
+
+    let listener = Listener::new(&path, false).unwrap();
+    barrier.wait();
+    daemon.start(listener).unwrap();
+    barrier.wait();
+
+    // handle service requests from clients.
+    thread.join().unwrap();
+}
+
+#[test]
+fn test_vhost_user_server() {
+    vhost_user_server(vhost_user_client);
+}
+
+fn vhost_user_enable(path: &Path, barrier: Arc<Barrier>) {
+    let master = setup_master(path, barrier);
+    master.set_owner().unwrap();
+    master.set_owner().unwrap_err();
+}
+
+#[test]
+fn test_vhost_user_enable() {
+    vhost_user_server(vhost_user_enable);
+}
+
+fn vhost_user_set_inflight(path: &Path, barrier: Arc<Barrier>) {
+    let mut master = setup_master(path, barrier);
+    let eventfd = EventFd::new(0).unwrap();
+    // No implementation for inflight_fd yet.
+    let inflight = VhostUserInflight {
+        mmap_size: 0x100000,
+        mmap_offset: 0,
+        num_queues: 1,
+        queue_size: 256,
+    };
+    master
+        .set_inflight_fd(&inflight, eventfd.as_raw_fd())
+        .unwrap_err();
+}
+
+#[test]
+fn test_vhost_user_set_inflight() {
+    vhost_user_server(vhost_user_set_inflight);
+}
+
+fn vhost_user_get_inflight(path: &Path, barrier: Arc<Barrier>) {
+    let mut master = setup_master(path, barrier);
+    // No implementation for inflight_fd yet.
+    let inflight = VhostUserInflight {
+        mmap_size: 0x100000,
+        mmap_offset: 0,
+        num_queues: 1,
+        queue_size: 256,
+    };
+    assert!(master.get_inflight_fd(&inflight).is_err());
+}
+
+#[test]
+fn test_vhost_user_get_inflight() {
+    vhost_user_server(vhost_user_get_inflight);
+}


### PR DESCRIPTION
Previously VringStateGuard and VringStateMutGuard are defined as enum, which limits the extensibility of the interface. So convert them into traits by using the High Rank Trait Bound tricky.

This MR also includes several commits to prepare for publishing vhost-user-backend.