### PR TITLE
lib: Allow the daemon to run as a client

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.1,
+  "coverage_score": 85.0,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
In order to support vhost-user client mode, we introduce a new method
start_client() to VhostUserDaemon. It allows the daemon to connect to
the VMM side running as the server in this case.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>