### PR TITLE
deps: Update virtio-queue dependency to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ libc = ">=0.2.39"
 log = ">=0.4.6"
 vhost = { version = "0.3", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1"
-virtio-queue = "0.1"
+virtio-queue = "0.2"
 vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic"]}
 vmm-sys-util = "0.9"
 


### PR DESCRIPTION
### Summary of the PR

Updating the `virtio-queue` crate dependency to rely on the latest version.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
