### PR TITLE
build: Relax vm-memory dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ log = ">=0.4.6"
 vhost = { version = "0.4", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1"
 virtio-queue = "0.2"
-vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic"]}
+vm-memory = {version = ">=0.7", features = ["backend-mmap", "backend-atomic"]}
 vmm-sys-util = "0.9"
 
 [dev-dependencies]
 nix = "0.24"
 vhost = { version = "0.4", features = ["vhost-user-master", "vhost-user-slave"] }
-vm-memory = {version = "0.7", features = ["backend-mmap", "backend-atomic", "backend-bitmap"]}
+vm-memory = {version = ">=0.7", features = ["backend-mmap", "backend-atomic", "backend-bitmap"]}
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ libc = ">=0.2.39"
 log = ">=0.4.6"
 vhost = { version = "0.4", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1"
-virtio-queue = "0.2"
+virtio-queue = "0.3"
 vm-memory = {version = ">=0.7", features = ["backend-mmap", "backend-atomic"]}
 vmm-sys-util = "0.9"
 


### PR DESCRIPTION
This allows the use of newer versions of the vm-memory crate when
combined with other dependencies.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>