### PR TITLE
handler: Fix vring initialization logic

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -179,14 +179,11 @@ where
         let vring_state = vring.get_ref();
 
         // If the vring wasn't initialized and we already have an EventFd for
-        // both VRING_KICK and VRING_CALL, initialize it now.
-        !vring_state.get_queue().ready()
-            && vring_state.get_call().is_some()
-            && vring_state.get_kick().is_some()
+        // VRING_KICK, initialize it now.
+        !vring_state.get_queue().ready() && vring_state.get_kick().is_some()
     }
 
     fn initialize_vring(&self, vring: &V, index: u8) -> VhostUserResult<()> {
-        assert!(vring.get_ref().get_call().is_some());
         assert!(vring.get_ref().get_kick().is_some());
 
         if let Some(fd) = vring.get_ref().get_kick() {


### PR DESCRIPTION
### Summary of the PR

Since it's the guest decision to rely on polling or interrupts to be
notified about used descriptors in the used ring, we can't expect an
EventFd to be set through SET_VRING_CALL if the guest chose the polling
method.

On the other hand, we always expect an EventFd to be provided through
SET_VRING_KICK since the current way of handling new descriptors is
exclusively by receiving an event through an eventfd (no polling mode
has been implemented).

That's why a vring should be initialized based on its state and if the
EventFd related to VRING_KICK has been set.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
